### PR TITLE
Moving clone out of tests

### DIFF
--- a/destam/clone.js
+++ b/destam/clone.js
@@ -1,12 +1,12 @@
-import {observerGetter} from '../Observer.js';
-import OObject from '../Object.js';
-import OArray from '../Array.js';
-import OMap from '../UUIDMap.js';
-import UUID from '../UUID.js';
-import * as Network from '../Network.js';
-import {Insert, Modify, Delete} from '../Events.js';
-import {registerElement} from '../UUIDMap.js';
-import {assert} from '../util.js';
+import {observerGetter} from './Observer.js';
+import OObject from './Object.js';
+import OArray from './Array.js';
+import OMap from './UUIDMap.js';
+import UUID from './UUID.js';
+import * as Network from './Network.js';
+import {Insert, Modify, Delete} from './Events.js';
+import {registerElement} from './UUIDMap.js';
+import {assert} from './util.js';
 
 const wrap = (type, props) => {
 	return {

--- a/destam/index.js
+++ b/destam/index.js
@@ -6,3 +6,4 @@ export {default as OMap} from './UUIDMap.js';
 export {default as UUID} from './UUID.js';
 export * from './Events.js';
 export {default as createNetwork} from './Tracking.js';
+export * from './clone.js';

--- a/destam/tests/network.test.js
+++ b/destam/tests/network.test.js
@@ -6,7 +6,7 @@ import UUID from '../UUID.js';
 import OMap from '../UUIDMap.js';
 import createNetwork from '../Tracking.js';
 
-import { stringify, parse, clone } from './clone.js';
+import { stringify, parse, clone } from '../clone.js';
 
 [
 	(name, callback) => test("forward " + name, () => {

--- a/destam/tests/tracking.test.js
+++ b/destam/tests/tracking.test.js
@@ -6,7 +6,7 @@ import OMap from '../UUIDMap.js';
 import UUID from '../UUID.js';
 import createNetwork from '../Tracking.js';
 
-import { clone } from './clone.js';
+import { clone } from '../clone.js';
 
 [
 	(name, func) => test(name, async () => {

--- a/destam/tests/trackingDuplex.test.js
+++ b/destam/tests/trackingDuplex.test.js
@@ -1,12 +1,9 @@
 import {expect} from 'chai';
 import test from 'node:test';
 import OObject from '../Object.js';
-import OArray from '../Array.js';
-import OMap from '../UUIDMap.js';
-import UUID from '../UUID.js';
 import createNetwork from '../Tracking.js';
 
-import { clone } from './clone.js';
+import { clone } from '../clone.js';
 
 [
 	(name, func) => test('tracking duplex: ' + name, async () => {


### PR DESCRIPTION
I found I needed clone/parse/stringify to follow along with the examples in Networks.md and networks.test.js/tracking.test.js/trackingDuplex.test.js and thought it should be more of a main import since it's a good utility for using networks to avoid recursion errors (took me a while to figure out where clone was coming from in the examples). Then I found stringify and parse which made implementing a basic websocket thing a lot smoother than trying to figure out how to serialize and de-serialize observers.

I went through and ran all the tests, nothing broke, it looks good