### PR TITLE
Fix removeListener crash when an observable is shared across OArray indices

### DIFF
--- a/destam/Network.js
+++ b/destam/Network.js
@@ -77,8 +77,11 @@ const removeListener = (reg, parent) => {
 		// Reached either by explicit removal of a shadow (e.g. obj.y deleted
 		// while obj.x still references the same observable) or by the
 		// children walk above when parent is a cycle-shadow descendant.
-		while (active.shadow_ !== parent) active = active.shadow_;
-		active.shadow_ = parent.shadow_;
+		// Guard the walk: when the same observable is shared across OArray
+		// indices, parent can be absent from this governor's shadow chain, so
+		// walking unconditionally runs off the end and dereferences null.
+		while (active && active.shadow_ !== parent) active = active.shadow_;
+		if (active) active.shadow_ = parent.shadow_;
 	}
 
 	parent.shadow_ = null;

--- a/destam/tests/arraySharedObservable.test.js
+++ b/destam/tests/arraySharedObservable.test.js
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import OObject from '../Object.js';
+import OArray from '../Array.js';
+
+// Regression: a single observable may legitimately be referenced from more than
+// one place (the listener "shadow" mechanism exists for exactly this — see the
+// "network crazy" case in network.test.js, where the same observable is held by
+// both an OObject key and a UUIDMap). That worked for object keys but NOT for
+// OArray indices: reusing an existing element instance at another index (e.g. a
+// swap done as `splice(a, 1, arr[b])`) builds a shadow chain that
+// removeListener() later walks off the end of, throwing
+// "Cannot read properties of null (reading 'shadow_')".
+
+const createRng = (seed = 12345) => {
+	let s = seed >>> 0;
+	return () => {
+		s = (s * 1664525 + 1013904223) >>> 0;
+		return s / 0x100000000;
+	};
+};
+const pick = (rng, arr) => arr[Math.floor(rng() * arr.length)];
+
+test("OArray tolerates an observable shared across indices under heavy mutation", () => {
+	const rng = createRng(1337);
+	const doc = OObject({
+		items: OArray([
+			OObject({ label: 'a' }),
+			OObject({ label: 'b' }),
+			OObject({ label: 'c' }),
+			OObject({ label: 'd' }),
+		]),
+	});
+
+	// A live listener is required for the shadow bookkeeping to run at all.
+	const stop = doc.observer.watch(() => {});
+
+	const ops = ['push', 'pop', 'shift', 'unshift', 'splice', 'swap', 'replace'];
+	for (let i = 0; i < 5000; i++) {
+		const items = doc.items;
+		const len = items.length;
+		switch (pick(rng, ops)) {
+			case 'push': items.push(OObject({ label: `p${i}` })); break;
+			case 'pop': if (len) items.pop(); break;
+			case 'shift': if (len) items.shift(); break;
+			case 'unshift': items.unshift(OObject({ label: `u${i}` })); break;
+			case 'splice': {
+				const start = len ? Math.floor(rng() * len) : 0;
+				const del = len ? Math.floor(rng() * Math.min(3, len - start)) : 0;
+				const adds = Math.floor(rng() * 3);
+				const vals = [];
+				for (let j = 0; j < adds; j++) vals.push(OObject({ label: `s${i}-${j}` }));
+				items.splice(start, del, ...vals);
+				break;
+			}
+			case 'swap': {
+				// reuses existing element instances -> same observable briefly at two indices
+				if (len < 2) break;
+				const a = Math.floor(rng() * len);
+				let b = Math.floor(rng() * len);
+				if (b === a) b = (b + 1) % len;
+				const va = items[a];
+				const vb = items[b];
+				items.splice(a, 1, vb);
+				items.splice(b, 1, va);
+				break;
+			}
+			case 'replace': {
+				if (!len) break;
+				items[Math.floor(rng() * len)] = OObject({ label: `r${i}` });
+				break;
+			}
+		}
+	}
+
+	for (const item of doc.items) assert.ok(item instanceof OObject);
+	stop();
+});


### PR DESCRIPTION
## Problem

`removeListener` (destam/Network.js) walks a governor's shadow chain:

```js
while (active.shadow_ !== parent) active = active.shadow_;
active.shadow_ = parent.shadow_;
```

When the **same observable instance is referenced from multiple OArray indices**, `parent` can be absent from that governor's shadow chain, so the walk runs off the end and dereferences `null`:

```
TypeError: Cannot read properties of null (reading 'shadow_')
    at removeListener (destam/Network.js:80)
    at relink (destam/Network.js:114)
    at setProp (destam/Array.js)        ← arr[i] = x  /  splice
```

This is reachable through ordinary array mutation. A swap written as `arr.splice(a, 1, arr[b])` briefly places one observable at two indices; after enough such reuse the shadow bookkeeping reaches the unguarded walk.

## Why this is a real bug (not unsupported usage)

Sharing one observable across multiple references is a **supported, tested** feature — see `tests/network.test.js` **"network crazy"**, where the same observable is held by both an OObject key and a UUIDMap and selectively unlinked. That path works. The **OArray-index** case is the same capability but was simply untested, and it hits this unguarded walk.

Surfaced in a downstream consumer (an observable-document store) whose array reconciliation reuses element instances during sync.

## Fix

Guard the chain walk and the trailing assignment:

```js
while (active && active.shadow_ !== parent) active = active.shadow_;
if (active) active.shadow_ = parent.shadow_;
```

Adds `tests/arraySharedObservable.test.js` — a seeded mutation fuzz over an OArray that reuses element instances. It **fails before** this change (the null deref) and **passes after**.

- Regression test: crashes on `main`, passes with the guard
- Full existing suite: **659/659**

## Open question for review

The guard stops the crash, but `active` reaching `null` means `parent` was never in this governor's shadow chain. That may indicate the OArray relink path should have *registered* the shadow entry (a deeper bookkeeping fix) rather than just tolerating its absence — happy to take it that direction if you'd prefer the array-index sharing path register into the shadow chain to begin with.